### PR TITLE
(bugfix) Add exit on isTilgjengelig loop

### DIFF
--- a/src/app/hooks/useTilgjengelig.ts
+++ b/src/app/hooks/useTilgjengelig.ts
@@ -2,13 +2,20 @@ import { useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
 import api, { ApiEndpoint } from '../api/api';
 
-function useTilgjengelig() {
+function useTilgjengelig(isIntroPage = false) {
+    const [counter, setCounter] = useState<number>(0);
     const [isTilgjengelig, setIsTilgjengelig] = useState<boolean | undefined>();
     const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [error, setError] = useState<AxiosError | undefined>();
+    const [error, setError] = useState<AxiosError | Error | undefined>();
 
     async function checkTilgjengelig() {
         setIsLoading(true);
+        setCounter(counter + 1);
+        if (isIntroPage && counter > 10) {
+            const error = new Error('Tilgjengelig called 10 times');
+            setError(error);
+            throw error;
+        }
         try {
             await api.get<any>(ApiEndpoint.tilgjengelig);
             setIsTilgjengelig(true);

--- a/src/app/i18n/nb.json
+++ b/src/app/i18n/nb.json
@@ -86,5 +86,5 @@
 
     "page.generalErrorPage.sidetittel": "Feil",
     "page.generalErrorPage.tittel": "Noe gikk galt...",
-    "page.generalErrorPage.tekst": "Beklager, her har det dessverre skjedd en feil. Vennligst gå tilbake og prøv igjen. Dersom feilen fortsetter, prøv igjen litt senere."
+    "page.generalErrorPage.tekst": "Beklager, her har det dessverre skjedd en feil. Dersom feilen fortsetter, prøv igjen litt senere."
 }

--- a/src/app/pages/intro-page/IntroPage.tsx
+++ b/src/app/pages/intro-page/IntroPage.tsx
@@ -33,7 +33,7 @@ const IntroPage: React.StatelessComponent = () => {
     const [introResult, setIntroResult] = useState<IntroResultProps | undefined>();
 
     const intl = useIntl();
-    const tilgjengeligFetcher = useTilgjengelig();
+    const tilgjengeligFetcher = useTilgjengelig(true);
     const soknadsperiodeFetcher = useSoknadsperiode(false);
 
     const { isTilgjengelig } = tilgjengeligFetcher;


### PR DESCRIPTION
Try to prevent loop in tilgjengelit api call. Not able to reproduce the error, but has now added a counter which throws an error if the counter passes 10.